### PR TITLE
Update Tile.cs

### DIFF
--- a/Yugen.Mosaic.Uwp/Models/Tile.cs
+++ b/Yugen.Mosaic.Uwp/Models/Tile.cs
@@ -40,7 +40,7 @@ namespace Yugen.Mosaic.Uwp.Models
 
         public void Dispose()
         {
-            ResizedImage.Dispose();
+            ResizedImage?.Dispose();
             ResizedImage = null;
         }
     }


### PR DESCRIPTION
Avoid  the 'Object reference not set to an instance of an object.' error